### PR TITLE
This changes the README clone instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project assumes that you have the following installed:
 First, clone this repository:
 
 ```bash
-git clone https://github.com/mediacurrent/a11y-training.git
+git clone git@github.com:mediacurrent/a11y-training.git
 ```
 
 Second, open the location where you cloned/downloaded the project in your terminal/prompt and start DDEV.


### PR DESCRIPTION
Note sure if this is wanted, but figured I could make a PR to see what you thought Mario.

It turns out my authentication issues were related to cloning the repo from HTTPS instead of SSH. Once I set the remote origin to SSH, everything worked fine.

This changes the README to instruct people to clone the repo with SSH. 